### PR TITLE
チャット画面の自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(function () {
   function buildHTML(message) {
     if (message.image) {
-      var html = `<div class="message-box">
+      var html = `<div class="message-box" data-message-id=${message.id}>
         <div class="message-box__contributor-info">
           <p class="message-box__contributor-info__user-name">
             ${message.user_name}
@@ -19,7 +19,7 @@ $(function () {
       </div>`;
       return html;
     } else {
-      var html = `<div class="message-box">
+      var html = `<div class="message-box" data-message-id=${message.id}>
         <div class="message-box__contributor-info">
           <p class="message-box__contributor-info__user-name">
             ${message.user_name}
@@ -61,4 +61,29 @@ $(function () {
         $(".new-message__submit-btn").prop("disabled", false);
       });
   });
+  var reloadMessages = function () {
+    var last_message_id = $(".message-box:last").data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: "get",
+      dataType: "json",
+      data: { id: last_message_id },
+    })
+      .done(function (messages) {
+        if (messages.length !== 0) {
+          var insertHTML = "";
+          $.each(messages, function (i, message) {
+            insertHTML += buildHTML(message);
+          });
+          $(".messages").append(insertHTML);
+          $(".messages").animate({ scrollTop: $(".messages")[0].scrollHeight });
+        }
+      })
+      .fail(function () {
+        alert("error");
+      });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+        group = Group.find(params[:group_id])
+        last_message_id = params[:id].to_i
+        @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message-box
+.message-box{data: {message: {id: message.id}}}
   .message-box__contributor-info
     %p.message-box__contributor-info__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index,:edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# what
・チャット画面の自動更新機能の実装
・7秒おきに、メッセージのうち最も新しいものを取得する。
・チャット画面以外では更新されない。

# why
別のユーザーの投稿メッセージはリロードしなければ表示されない為、自動で
チャット画面が表示されるようにする為

https://i.gyazo.com/db69f9c6226966db9bbb226fd2152623.mp4
